### PR TITLE
Update Texture on Player Login

### DIFF
--- a/ls_Monobrow/init.lua
+++ b/ls_Monobrow/init.lua
@@ -79,6 +79,7 @@ addon:RegisterEvent("ADDON_LOADED", function(arg)
 
 	addon:RegisterEvent("PLAYER_LOGIN", function()
 		addon.Font:Update()
+		bar:UpdateTextures()
 
 		-- to fetch and cache the tracked house data
 		local guid = C_Housing.GetTrackedHouseGuid()


### PR DESCRIPTION
Current behavior makes the addon assign the default texture until the user manually adjusts the texture in options.